### PR TITLE
fixes #21: make dialog functions reusable

### DIFF
--- a/dialog.js
+++ b/dialog.js
@@ -8,37 +8,23 @@ export function toggleDialog(dialog, action) {
   }
 }
 
-export function toggleHelpDialogClasses(settingsIcon, fillModeLabel, guessModeLabel, action) {
+export function toggleHelpDialogClasses(
+  settingsIcon,
+  fillModeLabel,
+  guessModeLabel,
+  action,
+) {
   if (action === "open") {
     settingsIcon.classList.remove("fill-current");
+    settingsIcon.classList.remove("text-brand-300", "dark:text-brand-700");
     settingsIcon.classList.add("text-error", "dark:text-error");
 
-    if (fillModeLabel.classList.contains("active")) {
-      fillModeLabel.classList.add("activeHelpDialog");
-    } else {
-      fillModeLabel.classList.add("text-error");
-    }
-
-    if (guessModeLabel.classList.contains("active")) {
-      guessModeLabel.classList.add("activeHelpDialog");
-    } else {
-      guessModeLabel.classList.add("text-error");
-    }
+    fillModeLabel.classList.add("activeHelpDialog");
+    guessModeLabel.classList.add("activeHelpDialog");
   } else if (action === "close") {
     settingsIcon.classList.add("fill-current");
     settingsIcon.classList.remove("text-error", "dark:text-error");
-
-    if (fillModeLabel.classList.contains("active")) {
-      fillModeLabel.classList.remove("activeHelpDialog");
-    } else {
-      fillModeLabel.classList.remove("text-error");
-    }
-
-    if (guessModeLabel.classList.contains("active")) {
-      guessModeLabel.classList.remove("activeHelpDialog");
-    } else {
-      guessModeLabel.classList.remove("text-error");
-      guessModeLabel.classList.add("text-brand-950", "dark:text-brand-600");
-    }
+    fillModeLabel.classList.remove("activeHelpDialog");
+    guessModeLabel.classList.remove("activeHelpDialog");
   }
 }

--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@
         <label
           for="fillMode"
           id="fillModeLabel"
-          class="active cursor-pointer flex justify-center peer-checked:bg-brand-600 peer-checked:text-brand-100 w-1/2"
+          class="active cursor-pointer flex justify-center peer-checked:bg-brand-600 peer-checked:text-brand-100 w-1/2 transition-colors duration-350 ease-in-out"
         >
           Fill
           <input

--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import { toggleDialog, toggleHelpDialogClasses } from './dialog.js';
+import { toggleDialog, toggleHelpDialogClasses } from "./dialog.js";
 
 const helpDialog = document.getElementById("helpDialog");
 const settingsIcon = document.getElementById("settings");
@@ -67,21 +67,20 @@ let guessMode = false;
 let guessModeInput = document.getElementById("guessMode");
 let fillModeInput = document.getElementById("fillMode");
 
-fillModeInput.addEventListener("change", () => { 
-  toggleBetweenFillAndGuessMode(); 
+fillModeInput.addEventListener("change", () => {
+  toggleBetweenFillAndGuessMode();
 });
 guessModeInput.addEventListener("change", () => {
-  toggleBetweenFillAndGuessMode(); 
+  toggleBetweenFillAndGuessMode();
 });
 
-function toggleBetweenFillAndGuessMode(){
+function toggleBetweenFillAndGuessMode() {
   guessModeInput.parentElement.classList.toggle("active");
   fillModeInput.parentElement.classList.toggle("active");
 
   guessMode === true ? false : true;
   fillMode === true ? false : true;
 }
-
 
 document.getElementById("help").addEventListener("click", (event) => {
   toggleDialog(helpDialog, "open");
@@ -93,8 +92,15 @@ document.getElementById("help").addEventListener("click", (event) => {
   helpDialog.style.height = gameBoardWidth;
 
   toggleHelpDialogClasses(settingsIcon, fillModeLabel, guessModeLabel, "open");
+  // settingsIcon.classList.remove("fill-current");
+  // settingsIcon.classList.remove("text-brand-300", "dark:text-brand-700");
+  // settingsIcon.classList.add("text-error", "dark:text-error");
+
+  // fillModeLabel.classList.add("activeHelpDialog");
+  // guessModeLabel.classList.add("activeHelpDialog");
+
   event.stopPropagation();
-  });
+});
 
 // Event listener to close the dialog when clicking outside
 document.body.addEventListener("click", (event) => {
@@ -105,7 +111,7 @@ document.body.addEventListener("click", (event) => {
   ) {
     toggleDialog(helpDialog, "close");
 
-    toggleHelpDialogClasses(settingsIcon, fillModeLabel, guessModeLabel, "close");
+    toggleHelpDialogClasses(settingsIcon, fillModeLabel, guessModeLabel, "close")
   }
 });
 


### PR DESCRIPTION
Pulled dialog function into one `toggleDialog` function in `dialog.js` to clean up `main.js`.  

This function now works with both the help and settings Dialogs, although the event listeners remain in the main file.  

Set up initial styles for `settingsDialog`.  