### PR TITLE
replace ternary logic in  toggleBetweenFillAndGuessMode function with boolean negation

### DIFF
--- a/main.js
+++ b/main.js
@@ -78,8 +78,8 @@ function toggleBetweenFillAndGuessMode() {
   guessModeInput.parentElement.classList.toggle("active");
   fillModeInput.parentElement.classList.toggle("active");
 
-  guessMode === true ? false : true;
-  fillMode === true ? false : true;
+  guessMode = !guessMode;
+  fillMode = !fillMode;
 }
 
 document.getElementById("help").addEventListener("click", (event) => {


### PR DESCRIPTION
When making changes to show another nested grid for guessMode, I discovered that the current boolean logic in the toggleBetweenFillAndGuessMode function isn't actually inverting the values. Replaced the current logic with boolean negation logic to fix the issue. 

