### PR TITLE
Issue #25: Toggle clock

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,9 +50,9 @@
       <!-- TOP NAV BAR closes -->
 
       <!-- DIFFICULTY & TIMER -->
-      <div class="mx-6 flex items-center justify-between md:mx-24 lg:mx-44">
+      <div class="mx-6 flex items-center justify-between min-h-12 md:mx-24 lg:mx-44">
         <div class="text-lg font-extrabold" id="puzzleDifficulty">Easy</div>
-        <div class="flex items-center gap-6">
+        <div class="flex items-center gap-6" id="timerBlock">
           <div class="text-lg font-extrabold" id="puzzleTimer">1:23</div>
           <svg 
             xmlns="http://www.w3.org/2000/svg" 
@@ -89,32 +89,42 @@
       <!-- Settings Dialog-->
       <dialog id="settingsDialog" class="absolute top-0 bottom-0 left-0 right-0 h-full bg-brand-50 dark:bg-brand-800 flex flex-col justify-center items-start gap-9 font-semibold text-wrap text-brand-800 dark:text-brand-300 px-2 md:px-4 hidden gap-2 z-10">
         <div class="flex justify-between px-4 py-2 border w-full">
-          <button id="easyLevel">Easy</button>
-          <button id="mediumLevel">Medium</button>
-          <button id="hardLevel">Hard</button>
-          <button id="randomLevel">Random</button>
+          <button id="easyLevel" class="focus:outline-none focus:ring-0 hover:font-bold focus:font-bold">Easy</button>
+          <button id="mediumLevel" class="focus:outline-none focus:ring-0 hover:font-bold focus:font-bold">Medium</button>
+          <button id="hardLevel" class="focus:outline-none focus:ring-0 hover:font-bold focus:font-bold">Hard</button>
+          <button id="randomLevel" class="focus:outline-none focus:ring-0 hover:font-bold focus:font-bold">Random</button>
       </div>
         <div class="flex items-center gap-2">
           <button 
             id="autoCheckGuesses"
             aria-pressed="false" 
-            class="w-6 h-6 bg-gray-300 relative border-2 border-brand-400focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition"
+            class="w-6 h-6 bg-gray-300 relative border-2 border-brand-400 focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-brand-500 transition"
           >
             <span 
-              class="absolute left-1 top-1 w-4 h-4 transition-transform transform"
-            ></span>
+              class="absolute w-4 h-4 transition-transform transform"
+            >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-10 absolute -top-7 -right-2 hidden">
+              <path fill-rule="evenodd" d="M19.916 4.626a.75.75 0 0 1 .208 1.04l-9 13.5a.75.75 0 0 1-1.154.114l-6-6a.75.75 0 0 1 1.06-1.06l5.353 5.353 8.493-12.74a.75.75 0 0 1 1.04-.207Z" clip-rule="evenodd" />
+            </svg>
+            </span>
           </button>
           <span>Auto check guesses</span>
         </div>
-        <div class="flex items-center gap-2">
+        <div class="flex items-center gap-2 ">
           <button 
             id="showClock"
-            aria-pressed="false" 
-            class="w-6 h-6 bg-gray-300 relative border-2 border-brand-400focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition"
+            aria-pressed="true" 
+            role="checkbox"
+            class="w-6 h-6 bg-gray-300 relative border-2 border-brand-400 focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-brand-500 transition"
+            onClick="showClock()"
           >
             <span 
-              class="absolute left-1 top-1 w-4 h-4 transition-transform transform"
-            ></span>
+              class="absolute w-4 h-4 transition-transform transform relative"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-10 absolute -top-7 -right-6" id="clockToggleCheck">
+                <path fill-rule="evenodd" d="M19.916 4.626a.75.75 0 0 1 .208 1.04l-9 13.5a.75.75 0 0 1-1.154.114l-6-6a.75.75 0 0 1 1.06-1.06l5.353 5.353 8.493-12.74a.75.75 0 0 1 1.04-.207Z" clip-rule="evenodd" />
+              </svg>
+            </span>
           </button>
           <span>Show clock</span>
         </div>

--- a/main.js
+++ b/main.js
@@ -92,12 +92,6 @@ document.getElementById("help").addEventListener("click", (event) => {
   helpDialog.style.height = gameBoardWidth;
 
   toggleHelpDialogClasses(settingsIcon, fillModeLabel, guessModeLabel, "open");
-  // settingsIcon.classList.remove("fill-current");
-  // settingsIcon.classList.remove("text-brand-300", "dark:text-brand-700");
-  // settingsIcon.classList.add("text-error", "dark:text-error");
-
-  // fillModeLabel.classList.add("activeHelpDialog");
-  // guessModeLabel.classList.add("activeHelpDialog");
 
   event.stopPropagation();
 });

--- a/main.js
+++ b/main.js
@@ -7,6 +7,9 @@ const settingsIcon = document.getElementById("settings");
 const fillModeLabel = document.getElementById("fillModeLabel");
 const guessModeLabel = document.getElementById("guessModeLabel");
 const settingsDialog = document.getElementById("settingsDialog");
+const clockToggle = document.getElementById("showClock");
+const timerBlock = document.getElementById("timerBlock");
+const clockToggleCheck = document.getElementById("clockToggleCheck");
 
 const practiseBoard = [
   [1, 2, 3, 4, 5, 6, 7, 8, 9],
@@ -82,6 +85,28 @@ function toggleBetweenFillAndGuessMode() {
   fillMode = !fillMode;
 }
 
+// Toggle clock
+let clockIsActive = true;
+function toggleClock() {
+  clockToggle.checked = !clockToggle.checked;
+  if (clockToggle.checked) {
+    timerBlock.classList.toggle("hidden");
+    clockToggleCheck.classList.toggle("hidden");
+    clockToggle.ariaPressed = "false";
+    clockIsActive = false;
+  } else {
+    timerBlock.classList.toggle("hidden");
+    clockToggleCheck.classList.toggle("hidden");
+    clockToggle.areaPressed = "true";
+    clockIsActive = true;
+  }
+}
+
+clockToggle.addEventListener("click", () => {
+  toggleClock();
+});
+
+// Toggle help & settings dialog
 document.getElementById("help").addEventListener("click", (event) => {
   toggleDialog(helpDialog, "open");
 
@@ -105,7 +130,12 @@ document.body.addEventListener("click", (event) => {
   ) {
     toggleDialog(helpDialog, "close");
 
-    toggleHelpDialogClasses(settingsIcon, fillModeLabel, guessModeLabel, "close")
+    toggleHelpDialogClasses(
+      settingsIcon,
+      fillModeLabel,
+      guessModeLabel,
+      "close",
+    );
   }
 });
 


### PR DESCRIPTION
Users are to have a way to show or hide the clock from the `settingsDialog`.  It made sense to start it off visible.

I changed the html `aria-pressed="true"` and added a `role="checkbox"` as it's styled as a checkbox, to add accessibility after removing `ring` classes.  Line 114.

I used a check mark icon from heroicons to signal it's state to the user.  I had to provide some crazy positioning to get it in the checkbox, so I also modified 'Auto check guesses" while I was at it.

I created the JS code starting at line 89 in `main.js` for the moment, as I'm not sure if it's best to place in it's own file yet.  I added a `clockIsActive` bool in case we want this for localStorage later.

I tested in all the browsers I have: Chrome, Chrome Canary, Opera, Arc, Edge, and Firefox.  Firefox initially displayed the checkmark in a different location, so this may need to be checked again.  I tested mobile, tablet and desktop in all.

I added a minimum height at line 53 in `index.html` to prevent a shift when toggling the `puzzleTimer` and pause icon.  
![Untitled__5_-removebg-preview](https://github.com/user-attachments/assets/23fe90cc-2cd2-4caf-8d03-ee03b2500cad)

*Don't worry about the 'black box' showing in the light screenshot.  I used a background remover and it went crazy!*

I also removed the weird focus state around the Easy, Medium, Hard and Random.  Not connected to this issue - so sorry!





