### PR TITLE
feat: add light dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,16 +25,17 @@
           </svg>
         </button>
 
-        <div class="flex gap-4">
-          <svg 
-            xmlns="http://www.w3.org/2000/svg" 
-            viewBox="0 0 24 24" 
-            fill="currentColor" 
-            id="mode" 
-            class="fill-current text-brand-300 dark:text-brand-700 size-10 cursor-pointer">
-            <path fill-rule="evenodd" d="M9.528 1.718a.75.75 0 0 1 .162.819A8.97 8.97 0 0 0 9 6a9 9 0 0 0 9 9 8.97 8.97 0 0 0 3.463-.69.75.75 0 0 1 .981.98 10.503 10.503 0 0 1-9.694 6.46c-5.799 0-10.5-4.7-10.5-10.5 0-4.368 2.667-8.112 6.46-9.694a.75.75 0 0 1 .818.162Z" clip-rule="evenodd" />
-          <title>Switch to dark mode</title>
-          </svg>
+        <div class="flex justify-between gap-4">
+          <button id="lightDarkButton">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              class="fill-current text-brand-300 dark:text-brand-700 size-10 cursor-pointer">
+              <path fill-rule="evenodd" d="M9.528 1.718a.75.75 0 0 1 .162.819A8.97 8.97 0 0 0 9 6a9 9 0 0 0 9 9 8.97 8.97 0 0 0 3.463-.69.75.75 0 0 1 .981.98 10.503 10.503 0 0 1-9.694 6.46c-5.799 0-10.5-4.7-10.5-10.5 0-4.368 2.667-8.112 6.46-9.694a.75.75 0 0 1 .818.162Z" clip-rule="evenodd" />
+            <title>Switch to dark mode</title>
+            </svg>
+          </button>
           
           <svg 
             xmlns="http://www.w3.org/2000/svg" 
@@ -71,7 +72,7 @@
     <!-- GAME BOARD -->
     <div class="relative">
       <div
-        class="grid grid-cols-3 h-64 w-screen border border-4 border-brand-100 md:mx-auto md:w-5/6 lg:w-2/5 my-6 relative"
+        class="grid grid-cols-3 h-64 w-screen border border-4 border-brand-100 md:mx-auto md:w-3/6 lg:w-2/6 my-6 relative"
         id="gameBoard"
       ></div>
       <!-- DIALOGS -->

--- a/lightDarkMode.js
+++ b/lightDarkMode.js
@@ -1,0 +1,37 @@
+export function toggleLightDarkMode() {
+  const root = document.documentElement;
+  const isDarkMode = root.classList.contains("dark");
+
+  if (isDarkMode) {
+    document.documentElement.classList.remove("dark");
+    localStorage.setItem("theme", "light");
+    lightDarkButton.innerHTML = MoonIcon;
+  } else {
+    document.documentElement.classList.add("dark");
+    localStorage.setItem("theme", "dark");
+    lightDarkButton.innerHTML = SunIcon;
+  }
+}
+
+export const SunIcon = `
+<svg 
+  xmlns="http://www.w3.org/2000/svg" 
+  viewBox="0 0 512 512" 
+  class="fill-current size-10 text-brand-300 dark:text-brand-700"
+  style="width: 2rem; height: 2rem;">
+  <path d="M375.7 19.7c-1.5-8-6.9-14.7-14.4-17.8s-16.1-2.2-22.8 2.4L256 61.1 173.5 4.2c-6.7-4.6-15.3-5.5-22.8-2.4s-12.9 9.8-14.4 17.8l-18.1 98.5L19.7 136.3c-8 1.5-14.7 6.9-17.8 14.4s-2.2 16.1 2.4 22.8L61.1 256 4.2 338.5c-4.6 6.7-5.5 15.3-2.4 22.8s9.8 13 17.8 14.4l98.5 18.1 18.1 98.5c1.5 8 6.9 14.7 14.4 17.8s16.1 2.2 22.8-2.4L256 450.9l82.5 56.9c6.7 4.6 15.3 5.5 22.8 2.4s12.9-9.8 14.4-17.8l18.1-98.5 98.5-18.1c8-1.5 14.7-6.9 17.8-14.4s2.2-16.1-2.4-22.8L450.9 256l56.9-82.5c4.6-6.7 5.5-15.3 2.4-22.8s-9.8-12.9-17.8-14.4l-98.5-18.1L375.7 19.7zM269.6 110l65.6-45.2 14.4 78.3c1.8 9.8 9.5 17.5 19.3 19.3l78.3 14.4L402 242.4c-5.7 8.2-5.7 19 0 27.2l45.2 65.6-78.3 14.4c-9.8 1.8-17.5 9.5-19.3 19.3l-14.4 78.3L269.6 402c-8.2-5.7-19-5.7-27.2 0l-65.6 45.2-14.4-78.3c-1.8-9.8-9.5-17.5-19.3-19.3L64.8 335.2 110 269.6c5.7-8.2 5.7-19 0-27.2L64.8 176.8l78.3-14.4c9.8-1.8 17.5-9.5 19.3-19.3l14.4-78.3L242.4 110c8.2 5.7 19 5.7 27.2 0zM256 368a112 112 0 1 0 0-224 112 112 0 1 0 0 224zM192 256a64 64 0 1 1 128 0 64 64 0 1 1 -128 0z" fill="currentColor"/>
+  <title>Switch to light mode</title>
+</svg>`;
+
+export const MoonIcon = `
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 24 24"
+  fill="currentColor"
+  id="darkModeIcon"
+  class="fill-current text-brand-300 dark:text-brand-700 size-10 cursor-pointer">
+  <path fill-rule="evenodd" d="M9.528 1.718a.75.75 0 0 1 .162.819A8.97 8.97 0 0 0 9 6a9 9 0 0 0 9 9 8.97 8.97 0 0 0 3.463-.69.75.75 0 0 1 .981.98 10.503 10.503 0 0 1-9.694 6.46c-5.799 0-10.5-4.7-10.5-10.5 0-4.368 2.667-8.112 6.46-9.694a.75.75 0 0 1 .818.162Z" clip-rule="evenodd" />
+  <title>Switch to dark mode</title>
+</svg>
+`;
+

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 "use strict";
 
 import { toggleDialog, toggleHelpDialogClasses } from "./dialog.js";
+import { toggleLightDarkMode, SunIcon, MoonIcon } from "./lightDarkMode.js";
 
 let fillMode = true;
 let guessMode = false;
@@ -9,6 +10,7 @@ let guessModeInput = document.getElementById("guessMode");
 let fillModeInput = document.getElementById("fillMode");
 
 const helpDialog = document.getElementById("helpDialog");
+const lightDarkButton = document.getElementById("lightDarkButton");
 const settingsIcon = document.getElementById("settings");
 const fillModeLabel = document.getElementById("fillModeLabel");
 const guessModeLabel = document.getElementById("guessModeLabel");
@@ -85,6 +87,7 @@ function createGuessNumberCell(outerGridCellIndex, innerGridCellIndex, guessCell
   guessCell.classList.add(["flex"]);
   guessCell.classList.add(["justify-center"]);
   guessCell.classList.add(["items-center"]);
+  guessCell.classList.add(["text-xs"]);
   guessCell.setAttribute(`id`, `cell-${outerGridCellIndex}-${innerGridCellIndex}-${guessCellIndex}`);
   guessCell.innerText = guessCellIndex+1;
 
@@ -188,3 +191,22 @@ document.body.addEventListener("click", (event) => {
     toggleDialog(settingsDialog, "close");
   }
 });
+
+// set light/dark mode based on user preference
+document.addEventListener("DOMContentLoaded", () => {
+  const storedPreference = localStorage.getItem("theme");
+  const systemPreference = window.matchMedia("(prefers-color-scheme: dark)").matches;
+
+  if (storedPreference === "dark" || (!storedPreference && systemPreference)) {
+    document.documentElement.classList.add("dark");
+    lightDarkButton.innerHTML = SunIcon;
+  } else {
+    document.documentElement.classList.remove("dark");
+    lightDarkButton.innerHTML = MoonIcon;
+  };
+})
+
+// toggle light/dark mode
+lightDarkButton.addEventListener("click", () => {
+  toggleLightDarkMode();
+})

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: "class",
   content: ["./index.html", "./main.js"],
   theme: {
     colors: {
@@ -26,11 +27,11 @@ export default {
     function ({ addUtilities }) {
       addUtilities({
         ".no-scrollbar": {
-          "scrollbar-width": "none", /* Firefox */
-          "-ms-overflow-style": "none", /* IE 10+ */
+          "scrollbar-width": "none" /* Firefox */,
+          "-ms-overflow-style": "none" /* IE 10+ */,
         },
         "no-scrollbar::-webkit-scrollbar": {
-          display: "none", /* All other browsers */
+          display: "none" /* All other browsers */,
         },
       });
     },


### PR DESCRIPTION
This was to make the light/dark mode toggle functional.

Steps I took:

- Added `button` element to enclose icon for semantic HTML and accessibililty.
- Added listener for `DOMContentLoaded` to search for any stored user preferences and system preferences in that order.
- System preferences will ensure the first load will follow either OS or browser settings.
- User preferences are stored in local storage, so if the user toggles the icon it will remember which mode it was set to.
- Change icon based on preferences.
- Add ability to toggle between.  
![image](https://github.com/user-attachments/assets/d7e9ebaa-37a8-4f4d-8d22-13aa338f0595)
![image](https://github.com/user-attachments/assets/cdedb5d7-341b-4779-ac0d-e3a6cbd01651)

The event listeners are in `main.js` and the toggle function is exported from `lightDarkMode.js`.

Tested on:
Windows:
- Chrome 131.0.6778.265 (64-bit)
- Chrome Canary 134.0.6956.0 (64-bit)
- Firefox Developer Edition
- Opera GX 
- Arc
- Edge 131.0.2903.146 (64-bit)

This is seem in the Responsively App:
![image](https://github.com/user-attachments/assets/66b41a32-facd-4125-a8cb-ef59ea5abf80)
