### PR TITLE
feat: make the timer functional

### DIFF
--- a/clockTimer.js
+++ b/clockTimer.js
@@ -1,0 +1,57 @@
+import { clockIsActive, gameRunning } from "./main";
+
+const clockDisplay = document.getElementById("puzzleTimer");
+const pauseTimerBtn = document.getElementById("pause");
+
+let startTime;
+let timerInterval;
+let elapsedTime = 0;
+
+export function startTimer() {
+  startTime = Date.now() - elapsedTime;
+  timerInterval = setInterval(updateTimer, 1000);
+}
+
+export function updateTimer() {
+  elapsedTime = Date.now() - startTime;
+  const seconds = Math.floor((elapsedTime / 1000) % 60);
+  const minutes = Math.floor((elapsedTime / 1000 / 60) % 60);
+  const hours = Math.floor(elapsedTime / 1000 / 60 / 60);
+  clockDisplay.innerText = hours
+    ? `${hours}:${minutes}:${seconds.toString().padStart(2, "0")}`
+    : `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+document.addEventListener("visibilitychange", () => {
+  if (document.hidden) {
+    clearInterval(timerInterval);
+  } else {
+    startTimer();
+  }
+});
+
+export function pauseTimer() {
+  clearInterval(timerInterval);
+}
+
+export function stopTimer() {
+  clearInterval(timerInterval);
+}
+
+export function resetTimer() {
+  clearInterval(timerInterval);
+  elapsedTime = 0;
+  clockDisplay.innerText = "0:00";
+}
+
+pauseTimerBtn.addEventListener("click", () => {
+  if (clockIsActive && pauseTimerBtn.ariaPressed === "false") {
+    pauseTimerBtn.ariaPressed = "true";
+    pauseTimer();
+  } else if (clockIsActive && pauseTimerBtn.ariaPressed === "true") {
+    pauseTimerBtn.ariaPressed = "false";
+    startTimer();
+  }
+});
+
+// TODO: Add event listener to reset timer when game is reset or over.

--- a/index.html
+++ b/index.html
@@ -58,13 +58,12 @@
       <div class="mx-6 flex items-center justify-between min-h-12 md:mx-24 lg:mx-44">
         <div class="text-lg font-extrabold" id="puzzleDifficulty">Easy</div>
         <div class="flex items-center gap-6" id="timerBlock">
-          <div class="text-lg font-extrabold" id="puzzleTimer">1:23</div>
-          <button aria-label="Pause timer.">
+          <div class="text-lg font-extrabold" id="puzzleTimer">0:00</div>
+          <button aria-label="Pause timer." aria-pressed="false" id="pause">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 24 24"
               fill="currentColor"
-              id="pause"
               class="size-12 fill-current text-brand-300 dark:text-brand-700 cursor-pointer">
               <path fill-rule="evenodd" d="M6.75 5.25a.75.75 0 0 1 .75-.75H9a.75.75 0 0 1 .75.75v13.5a.75.75 0 0 1-.75.75H7.5a.75.75 0 0 1-.75-.75V5.25Zm7.5 0A.75.75 0 0 1 15 4.5h1.5a.75.75 0 0 1 .75.75v13.5a.75.75 0 0 1-.75.75H15a.75.75 0 0 1-.75-.75V5.25Z" clip-rule="evenodd" />
             <title>Pause</title>

--- a/main.js
+++ b/main.js
@@ -2,6 +2,14 @@
 
 import { toggleDialog, toggleHelpDialogClasses } from "./dialog.js";
 import { toggleLightDarkMode, SunIcon, MoonIcon } from "./lightDarkMode.js";
+import {
+  startTimer,
+  stopTimer,
+  resetTimer,
+} from "./clockTimer.js";
+
+// TODO When we get the puzzle working, we need to change this to false.
+export let gameRunning = true;
 
 let fillMode = true;
 let guessMode = false;
@@ -125,7 +133,7 @@ function toggleBetweenFillAndGuessMode() {
 }
 
 // Toggle clock
-let clockIsActive = true;
+export let clockIsActive = true;
 function toggleClock() {
   clockToggle.checked = !clockToggle.checked;
   if (clockToggle.checked) {
@@ -144,6 +152,10 @@ function toggleClock() {
 clockToggle.addEventListener("click", () => {
   toggleClock();
 });
+
+if (gameRunning && clockIsActive) {
+  startTimer();
+}
 
 // Toggle help & settings dialog
 document.getElementById("help").addEventListener("click", (event) => {


### PR DESCRIPTION
Add a module `clockTimer.js` to start, pause, reset and stop the timer.

![image](https://github.com/user-attachments/assets/86338e44-3cd3-4067-bda6-2b5f88b7fabe)
![image](https://github.com/user-attachments/assets/f462704c-34f5-4b13-a4f9-402ab07e43fc)


## Changes made
In `index.html`:
- Moved the id `pause` from the svg to the button.
- Changed the initial time to **0:00**.

In `clockTimer.js`: 
- Created `startTimer`, `updateTimer`, `pauseTimer` to support our current functionality.
- Set it up to pause when the tab loses focus.
- Hooked up to pause button.
- Change font-weight of display when paused.
- Changed aria-pressed attributes accordingly.
- Initially set up `resetTimer` function for when game is over.

In `main.js`:
- Export `gameRunning` variable.
- Import needed functions.
- Called `startTimer` on line 155 after `clockIsActive` variable to start the timer.  

## How To Test
1️⃣ Start the game and verify that the timer begins counting.
2️⃣ Click the pause button and confirm that the timer stops.
3️⃣ Switch to another tab and return—confirm that the timer pauses while inactive.

## Head Scratchers
Currently the timer continues even when the clock isn't shown.  While working on pausing it, I wondered whether we would won't to leave it?
- Maybe users would want to see their completed time after the game, but find it annoying when playing?
- If we want to keep their scores later in local state or a database to track high scores?  